### PR TITLE
Remove compilation flags that prevents building against BOOST 1.67+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CMakeDependentOption)
 set(CMAKE_CXX_COMPILER g++)
 
 add_definitions(-std=c++11 -march=native -g)
-add_definitions(-Wall -Wextra -Werror -pedantic -Wsign-conversion -Wold-style-cast)
+add_definitions(-Wall -Wextra -Werror -pedantic)
 add_definitions(-Wno-unused-function -Wno-nested-anon-types -Wno-keyword-macro)
 
 set(LIBRARIES ${LIBRARIES} rt numa pthread gflags)

--- a/src/rpc_impl/rpc_connect_handlers.cc
+++ b/src/rpc_impl/rpc_connect_handlers.cc
@@ -6,6 +6,8 @@
 
 namespace erpc {
 
+const unsigned int PRE_BUF_SIZE = 32 * 1024;
+
 // We need to handle all types of errors in remote arguments that the client can
 // make when calling create_session(), which cannot check for such errors.
 template <class TTr>
@@ -81,7 +83,7 @@ void Rpc<TTr>::handle_connect_req_st(const SmPkt &sm_pkt) {
 
   for (size_t i = 0; i < kSessionReqWindow; i++) {
     MsgBuffer &msgbuf_i = session->sslot_arr[i].pre_resp_msgbuf;
-    msgbuf_i = alloc_msg_buffer(TTr::kMaxDataPerPkt);
+    msgbuf_i = alloc_msg_buffer(PRE_BUF_SIZE);
 
     if (msgbuf_i.buf == nullptr) {
       // Cleanup everything allocated for this session

--- a/src/transport_impl/dpdk/dpdk_transport.cc
+++ b/src/transport_impl/dpdk/dpdk_transport.cc
@@ -33,6 +33,9 @@ DpdkTransport::DpdkTransport(uint16_t sm_udp_port, uint8_t rpc_id,
   // ID, so we don't need sm_udp_port like Raw transport.
   _unused(sm_udp_port);
 
+  // @TODO: double initialization workaround
+  eal_initialized = true;
+
   rt_assert(kHeadroom == 40, "Invalid packet header headroom for raw Ethernet");
   rt_assert(sizeof(pkthdr_t::headroom) == kInetHdrsTotSize, "Invalid headroom");
 

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -66,11 +66,13 @@ static void output_log_header(int level);
 #endif
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
+#undef LOG_INFO
 #define LOG_INFO(...)                                    \
   output_log_header(LOG_DEFAULT_STREAM, LOG_LEVEL_INFO); \
   fprintf(LOG_DEFAULT_STREAM, __VA_ARGS__);              \
   fflush(LOG_DEFAULT_STREAM)
 #else
+#undef LOG_INFO
 #define LOG_INFO(...) ((void)0)
 #endif
 


### PR DESCRIPTION
Without the patch following errors occurs when compiling against Boost 1.69.0:
* include/boost/function/function_template.hpp:638:69: error: use of old-style cast to ‘void*’ [-Werror=old-style-cast]
* include/boost/algorithm/string/detail/classification.hpp:85:55: error: conversion to ‘std::size_t’ {aka ‘long unsigned int’} from ‘boost::iterators::iterator_difference<const char*>::type’ {aka ‘long int’} may change the sign of the result [-Werror=sign-conversion]

Signed-off-by: Jakub Radtke <jakub.radtke@intel.com>