### PR TITLE
bugfix: fix dpdk_proc_type variable set error

### DIFF
--- a/src/transport_impl/dpdk/dpdk_transport.cc
+++ b/src/transport_impl/dpdk/dpdk_transport.cc
@@ -35,6 +35,9 @@ DpdkTransport::DpdkTransport(uint16_t sm_udp_port, uint8_t rpc_id,
     if (g_dpdk_initialized) {
       ERPC_INFO("DPDK transport for Rpc %u skipping DPDK EAL initialization.\n",
                 rpc_id);
+      dpdk_proc_type_ = ((rte_eal_process_type() == RTE_PROC_PRIMARY)
+                             ? DpdkProcType::kPrimary
+                             : DpdkProcType::kSecondary);
     } else {
       ERPC_INFO("DPDK transport for Rpc %u initializing DPDK EAL.\n", rpc_id);
 


### PR DESCRIPTION
when we use 'dpdk_dameon process', and run another process which has create more than one DpdkTransport elements, variable `dpdk_proc_type_` will not be set (except for first element) because `g_dpdk_initialized` is true and will miss setting it, which will cause a runtime_error at 
https://github.com/erpc-io/eRPC/blob/c516856d47c60359937d17650d9a5a210f7d1524/src/transport_impl/dpdk/dpdk_transport.cc#L196-L199

I find following comment
> Resolve bandwidth. XXX: For some reason, rte_eth_link_get() does not work
 > // in secondary DPDK processes in DPDK 19.11

I'm using DPDK 21.05, and rte_eth_link_get() also doesn't work well in secondary DPDK processes, so it will cause a runtime_error