### PR TITLE
Minor: fix assert in alloc_from_class

### DIFF
--- a/src/util/huge_alloc.h
+++ b/src/util/huge_alloc.h
@@ -203,7 +203,7 @@ class HugeAlloc {
 
     // Use the Buffers at the back to improve locality
     Buffer buffer = freelist_[size_class].back();
-    assert(buffer.class_size_ = class_max_size(size_class));
+    assert(buffer.class_size_ == class_max_size(size_class));
     freelist_[size_class].pop_back();
 
     stats_.user_alloc_tot_ += buffer.class_size_;


### PR DESCRIPTION
Hi Anuj! This is Liangcheng.
Happened to notice a minor typo in https://github.com/erpc-io/eRPC/blob/master/src/util/huge_alloc.h#L206 which reads `assert(buffer.class_size_ = class_max_size(size_class));`.
It gives me compiler error when running `cmake . -DPERF=OFF -DTRANSPORT=dpdk; make -j16`

```
/home/liangcheng/eRPC/src/util/huge_alloc.h:206:31: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
  206 |     assert(buffer.class_size_ = class_max_size(size_class));
      |            ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Adding `set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-parentheses")` to CMakeLists.txt can also resolve/bypass the error and give me successful make but I believe it was an unintended typo.

For context, my local setup:

* Operating system: 18.04.6 LTS (Bionic Beaver)
* NIC model: Mellanox Technologies MT27710 Family [ConnectX-4 Lx]
* DPDK version: 19.11.5
* rdma_core: compiled from source
* g++ (Ubuntu 11.1.0-1ubuntu1~18.04.1) 11.1.0

Thanks!

