### PR TITLE
feat: try to use pkg-config for find DPDK when RTE_SDK not defined

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,37 +333,44 @@ if(DPDK_NEEDED STREQUAL "true")
   else(WIN32)
     # Linux
     if(NOT DEFINED ENV{RTE_SDK})
-      message(FATAL "RTE_SDK is not defined")
+      message(STATUS "RTE_SDK is not defined, try to use pkg-config")
+      find_package(PkgConfig REQUIRED)
+      pkg_check_modules(PKG_DPDK_LIB IMPORTED_TARGET libdpdk)
+      if(NOT PKG_DPDK_LIB_FOUND) 
+        message(FATAL_ERROR "DPDK library not found")
+      endif()
+      set(LIBRARIES ${LIBRARIES} "-Wl,--whole-archive -Wl,--as-needed" PkgConfig::PKG_DPDK_LIB pthread "-Wl,--no-whole-archive")
+      include_directories(SYSTEM ${PKG_DPDK_LIB_INCLUDE_DIRS})
     else()
       set(RTE_SDK $ENV{RTE_SDK})
-    endif()
-    set(DPDK_INSTALL_DIR "${RTE_SDK}/build/install/usr/local")
+      set(DPDK_INSTALL_DIR "${RTE_SDK}/build/install/usr/local")
 
-    # DPDK installs libraries into local/lib on Mariner, but
-    # local/lib/x86_64-linux-gnu on Ubuntu
-    set(DPDK_LIB_DIR "${DPDK_INSTALL_DIR}/lib/x86_64-linux-gnu")
-    if(NOT EXISTS ${DPDK_LIB_DIR})
-      set(DPDK_LIB_DIR "${DPDK_INSTALL_DIR}/lib")
+      # DPDK installs libraries into local/lib on Mariner, but
+      # local/lib/x86_64-linux-gnu on Ubuntu
+      set(DPDK_LIB_DIR "${DPDK_INSTALL_DIR}/lib/x86_64-linux-gnu")
       if(NOT EXISTS ${DPDK_LIB_DIR})
-        message(FATAL_ERROR "${DPDK_LIB_DIR} not found. Did you run `ninja install`?")
+        set(DPDK_LIB_DIR "${DPDK_INSTALL_DIR}/lib")
+        if(NOT EXISTS ${DPDK_LIB_DIR})
+          message(FATAL_ERROR "${DPDK_LIB_DIR} not found. Did you run `ninja install`?")
+        endif()
       endif()
+  
+      # We use some hacky command-line and CMake magic to construct DPDK library list
+      execute_process(
+        COMMAND bash -c "PKG_CONFIG_PATH=${DPDK_LIB_DIR}/pkgconfig pkg-config --static --libs-only-l libdpdk"
+        OUTPUT_VARIABLE DPDK_PKGCONFIG_OUT RESULT_VARIABLE pkgconfig_ret)
+      if(pkgconfig_ret EQUAL "1")
+        message( FATAL_ERROR "Failed to run pkgconfig on DPDK (in ${DPDK_LIB_DIR}/pkgconfig). See error above.")
+      endif()
+  
+      string(STRIP ${DPDK_PKGCONFIG_OUT} DPDK_PKGCONFIG_OUT) # Remove newline from pkg-config output
+      set(LIBDPDK_LIBRARIES
+        "-Wl,--whole-archive -Wl,--as-needed -L${DPDK_LIB_DIR} ${DPDK_PKGCONFIG_OUT} -lpthread -Wl,--no-whole-archive")
+      set(LIBRARIES ${LIBRARIES} ${LIBDPDK_LIBRARIES})
+  
+      link_directories(${DPDK_LIB_DIR})
+      include_directories(SYSTEM ${DPDK_INSTALL_DIR}/include)      
     endif()
-
-    # We use some hacky command-line and CMake magic to construct DPDK library list
-    execute_process(
-      COMMAND bash -c "PKG_CONFIG_PATH=${DPDK_LIB_DIR}/pkgconfig pkg-config --static --libs-only-l libdpdk"
-      OUTPUT_VARIABLE DPDK_PKGCONFIG_OUT RESULT_VARIABLE pkgconfig_ret)
-    if(pkgconfig_ret EQUAL "1")
-      message( FATAL_ERROR "Failed to run pkgconfig on DPDK (in ${DPDK_LIB_DIR}/pkgconfig). See error above.")
-    endif()
-
-    string(STRIP ${DPDK_PKGCONFIG_OUT} DPDK_PKGCONFIG_OUT) # Remove newline from pkg-config output
-    set(LIBDPDK_LIBRARIES
-      "-Wl,--whole-archive -Wl,--as-needed -L${DPDK_LIB_DIR} ${DPDK_PKGCONFIG_OUT} -lpthread -Wl,--no-whole-archive")
-    set(LIBRARIES ${LIBRARIES} ${LIBDPDK_LIBRARIES})
-
-    link_directories(${DPDK_LIB_DIR})
-    include_directories(SYSTEM ${DPDK_INSTALL_DIR}/include)
   endif(WIN32)
 else()
   message(STATUS "DPDK not needed to build eRPC")

--- a/tests/util_tests/numautil_test.cc
+++ b/tests/util_tests/numautil_test.cc
@@ -1,4 +1,5 @@
 #include "util/numautils.h"
+#include <cstdio>
 using namespace erpc;
 
 int main() {


### PR DESCRIPTION
When we don't find RTE_SDK definition, originally directly use `message(FATAL_ERROR)` to throw an error and exit (BTW, originally `message(FATAL)` maybe a typo).

But for those users who not build DPDK from source code or don't setup RTE_SDK environment variables, there is not backup policy to build eRPC.

PKG-CONFIG is a widely used function to manage dependency for includes and libs, and it also can be easily used. So It maybe helpful to add pkg-config as a backup policy.